### PR TITLE
fix: remove the FromServices attribute on HttpContext in the BaseParameters

### DIFF
--- a/Source/SimpleEndpoints.Tests.Unit/ExtensionsTests.cs
+++ b/Source/SimpleEndpoints.Tests.Unit/ExtensionsTests.cs
@@ -29,7 +29,7 @@ public class ExtensionsTests
 	public async Task MapEndpoint_Should_MapSimpleEndpoint_RouteWithMethods()
 	{
 		// Arrange
-		await using var server = new TestServer(c => c.MapEndpoint<RouteWithMethodsEndpoint, NoParameters>());
+		await using var server = new TestServer(c => c.MapEndpoint<RouteWithMethodsEndpoint, BaseParameters>());
 		var client = await server.StartServerAsync();
 
 		// Act

--- a/Source/SimpleEndpoints.Tests.Unit/TestEndpoint.cs
+++ b/Source/SimpleEndpoints.Tests.Unit/TestEndpoint.cs
@@ -37,11 +37,16 @@ internal sealed class PatternFallbackEndpoint : TestEndpointBase
 	}
 }
 
-internal abstract class TestEndpointBase : ISimpleEndpoint<NoParameters>
+internal abstract class TestEndpointBase : ISimpleEndpoint<NoParameters>, ISimpleEndpoint<BaseParameters>
 {
 	public abstract void Configure(IEndpointConfig config);
 
-	public Task<IResult> HandleRequestAsync(NoParameters parameters)
+	public Task<IResult> HandleRequestAsync(NoParameters _)
+	{
+		return Task.FromResult(Results.NoContent());
+	}
+
+	public Task<IResult> HandleRequestAsync(BaseParameters _)
 	{
 		return Task.FromResult(Results.NoContent());
 	}

--- a/Source/SimpleEndpoints/Parameters.cs
+++ b/Source/SimpleEndpoints/Parameters.cs
@@ -16,7 +16,6 @@ public readonly struct NoParameters { }
 public readonly struct BaseParameters
 {
 	/// <inheritdoc cref="HttpContext"/>
-	[FromServices]
 	public HttpContext Context { get; init; }
 
 	/// <inheritdoc cref="HttpRequest"/>


### PR DESCRIPTION
Solves a crash when using the BaseParameters. Also improved the tests to cover this issue.